### PR TITLE
Fix typo in README

### DIFF
--- a/docker-with-slurm/README.md
+++ b/docker-with-slurm/README.md
@@ -4,7 +4,7 @@
 
 Launch the environment:
 
-    docker-compute up -d --build
+    docker-compose up -d --build
 
 
 Once the container is online, the Open OnDemand interface can be accessed at `http"//localhost:8080` with username `ood` and password `ood`.


### PR DESCRIPTION
Fix typo in `docker-with-slurm` directory